### PR TITLE
Some minor MacOSX fixes

### DIFF
--- a/cmake/toolchain/MacOSX_X86_32.toolchain
+++ b/cmake/toolchain/MacOSX_X86_32.toolchain
@@ -18,7 +18,7 @@ SET(CMAKE_SYSTEM_NAME MacOSX)
 SET(CMAKE_SYSTEM_VERSION 1)
 
 SET(TARGET_OS MacOSX)
-SET(TARGET_ARCH x86_32)
+SET(TARGET_ARCH X86_32)
 
 include(CMakeForceCompiler)
 CMAKE_FORCE_C_COMPILER(clang clang)
@@ -34,3 +34,6 @@ add_definitions("-DTARGET_OS=MacOSX")
 add_definitions("-DTARGET_ARCH=X86_32")
 add_definitions("-DOS_MacOSX")
 add_definitions("-DARCH_X86_32")
+
+#Use GTEST own tuple implementation for OSX
+ADD_DEFINITIONS ("-DGTEST_USE_OWN_TR1_TUPLE=1")

--- a/cmake/toolchain/MacOSX_X86_64.toolchain
+++ b/cmake/toolchain/MacOSX_X86_64.toolchain
@@ -18,7 +18,7 @@ SET(CMAKE_SYSTEM_NAME MacOSX)
 SET(CMAKE_SYSTEM_VERSION 1)
 
 SET(TARGET_OS MacOSX)
-SET(TARGET_ARCH x86_64)
+SET(TARGET_ARCH X86_64)
 
 include(CMakeForceCompiler)
 CMAKE_FORCE_C_COMPILER(clang clang)
@@ -34,3 +34,6 @@ add_definitions("-DTARGET_OS=MacOSX")
 add_definitions("-DTARGET_ARCH=X86_64")
 add_definitions("-DOS_MacOSX")
 add_definitions("-DARCH_X86_64")
+
+#Use GTEST own tuple implementation for OSX
+ADD_DEFINITIONS ("-DGTEST_USE_OWN_TR1_TUPLE=1")

--- a/modules/capu/include/capu/os/MacOSX/X86_32/Math.h
+++ b/modules/capu/include/capu/os/MacOSX/X86_32/Math.h
@@ -47,6 +47,7 @@ namespace capu
                 using capu::os::Math::Rad2Deg;
                 using capu::os::Math::Deg2Rad;
                 using capu::os::Math::Log2;
+                using capu::os::Math::Exp;
             };
         }
     }


### PR DESCRIPTION
- added missing "using" in math.h 32 bit
- toolchain fix (defines overwritten x86_64 <=> X86_64)
- removed unix / windows line endings mix in toolchain file
