### PR TITLE
64-Bit compatibility AtomicOperations + SmartPointer

### DIFF
--- a/modules/capu/include/capu/os/AtomicOperation.h
+++ b/modules/capu/include/capu/os/AtomicOperation.h
@@ -30,65 +30,242 @@ namespace capu
     class AtomicOperation: private os::arch::AtomicOperation
     {
     public:
-
         /**
          * atomically add 'summand' to an uint32_t
          * @param mem reference to the object
          * @param summand amount to add
          * @return returns the initial value of mem
          */
-        static uint32_t AtomicAdd32(volatile uint32_t& mem, uint32_t summand);
+        static uint32_t AtomicAdd(volatile uint32_t& mem, uint32_t summand);
 
         /**
-         * atomically subtract 'substrahend' from an uint32_t
+         * atomically add 'summand' to an int32_t
+         * @param mem reference to the object
+         * @param summand amount to add
+         * @return returns the initial value of mem
+         */
+        static int32_t AtomicAdd(volatile int32_t& mem, int32_t summand);
+
+        /**
+         * atomically add 'summand' to an uint64_t
+         * @param mem reference to the object
+         * @param summand amount to add
+         * @return returns the initial value of mem
+         */
+        static uint64_t AtomicAdd(volatile uint64_t& mem, uint64_t summand);
+
+        /**
+         * atomically add 'summand' to an int64_t
+         * @param mem reference to the object
+         * @param summand amount to add
+         * @return returns the initial value of mem
+         */
+        static int64_t AtomicAdd(volatile int64_t& mem, int64_t summand);
+
+
+        /**
+         * atomically subtract 'substrahend' to an uint32_t
          * @param mem reference to the object
          * @param subtrahend amount to subtract
          * @return returns the initial value of mem
          */
-        static uint32_t AtomicSub32(volatile uint32_t& mem, uint32_t subtrahend);
+        static uint32_t AtomicSub(volatile uint32_t& mem, uint32_t subtrahend);
+
+        /**
+         * atomically subtract 'substrahend' to an int32_t
+         * @param mem reference to the object
+         * @param subtrahend amount to subtract
+         * @return returns the initial value of mem
+         */
+        static int32_t AtomicSub(volatile int32_t& mem, int32_t subtrahend);
+
+        /**
+         * atomically subtract 'substrahend' to an uint64_t
+         * @param mem reference to the object
+         * @param subtrahend amount to subtract
+         * @return returns the initial value of mem
+         */
+        static uint64_t AtomicSub(volatile uint64_t& mem, uint64_t subtrahend);
+
+        /**
+         * atomically subtract 'substrahend' to an int64_t
+         * @param mem reference to the object
+         * @param subtrahend amount to subtract
+         * @return returns the initial value of mem
+         */
+        static int64_t AtomicSub(volatile int64_t& mem, int64_t subtrahend);
 
         /**
          * atomically increment an uint32_t
          * @param mem reference to the object
          * @return returns the initial value of mem
          */
-        static uint32_t AtomicInc32(volatile uint32_t& mem);
+        static uint32_t AtomicInc(volatile uint32_t& mem);
 
         /**
-         * atomically decrement  an uint32_t
+         * atomically increment an int32_t
          * @param mem reference to the object
          * @return returns the initial value of mem
          */
-        static uint32_t AtomicDec32(volatile uint32_t& mem);
+        static int32_t  AtomicInc(volatile int32_t& mem);
+
+        /**
+         * atomically increment an uint64_t
+         * @param mem reference to the object
+         * @return returns the initial value of mem
+         */
+        static uint64_t AtomicInc(volatile uint64_t& mem);
+
+        /**
+         * atomically increment an int64_t
+         * @param mem reference to the object
+         * @return returns the initial value of mem
+         */
+        static int64_t  AtomicInc(volatile int64_t& mem);
+
+        /**
+         * atomically decrement an uint32_t
+         * @param mem reference to the object
+         * @return returns the initial value of mem
+         */
+        static uint32_t AtomicDec(volatile uint32_t& mem);
+
+        /**
+         * atomically decrement an int32_t
+         * @param mem reference to the object
+         * @return returns the initial value of mem
+         */
+        static int32_t  AtomicDec(volatile int32_t& mem);
+
+        /**
+         * atomically decrement an uint64_t
+         * @param mem reference to the object
+         * @return returns the initial value of mem
+         */
+        static uint64_t AtomicDec(volatile uint64_t& mem);
+
+        /**
+         * atomically decrement an int64_t
+         * @param mem reference to the object
+         * @return returns the initial value of mem
+         */
+        static int64_t  AtomicDec(volatile int64_t& mem);
+
     };
 
 
     inline
     uint32_t
-    AtomicOperation::AtomicAdd32(volatile uint32_t& mem, uint32_t summand)
+    AtomicOperation::AtomicAdd(volatile uint32_t& mem, uint32_t summand)
     {
-        return os::arch::AtomicOperation::AtomicAdd32(mem, summand);
+        return os::arch::AtomicOperation::AtomicAdd(mem, summand);
+    }
+
+    inline
+    int32_t
+    AtomicOperation::AtomicAdd(volatile int32_t& mem, int32_t summand)
+    {
+        return os::arch::AtomicOperation::AtomicAdd(mem, summand);
+    }
+
+    inline
+    uint64_t
+    AtomicOperation::AtomicAdd(volatile uint64_t& mem, uint64_t summand)
+    {
+        return os::arch::AtomicOperation::AtomicAdd(mem, summand);
+    }
+
+    inline
+    int64_t
+    AtomicOperation::AtomicAdd(volatile int64_t& mem, int64_t summand)
+    {
+        return os::arch::AtomicOperation::AtomicAdd(mem, summand);
+    }
+
+
+    inline
+    uint32_t
+    AtomicOperation::AtomicSub(volatile uint32_t& mem, uint32_t subtrahend)
+    {
+        return os::arch::AtomicOperation::AtomicSub(mem, subtrahend);
+    }
+
+    inline
+    int32_t
+    AtomicOperation::AtomicSub(volatile int32_t& mem, int32_t subtrahend)
+    {
+        return os::arch::AtomicOperation::AtomicSub(mem, subtrahend);
+    }
+
+    inline
+    uint64_t
+    AtomicOperation::AtomicSub(volatile uint64_t& mem, uint64_t subtrahend)
+    {
+        return os::arch::AtomicOperation::AtomicSub(mem, subtrahend);
+    }
+
+    inline
+    int64_t
+    AtomicOperation::AtomicSub(volatile int64_t& mem, int64_t subtrahend)
+    {
+        return os::arch::AtomicOperation::AtomicSub(mem, subtrahend);
+    }
+
+
+    inline
+    uint32_t
+    AtomicOperation::AtomicInc(volatile uint32_t& mem)
+    {
+        return os::arch::AtomicOperation::AtomicInc(mem);
+    }
+
+    inline
+    int32_t
+    AtomicOperation::AtomicInc(volatile int32_t& mem)
+    {
+        return os::arch::AtomicOperation::AtomicInc(mem);
+    }
+
+    inline
+    uint64_t
+    AtomicOperation::AtomicInc(volatile uint64_t& mem)
+    {
+        return os::arch::AtomicOperation::AtomicInc(mem);
+    }
+
+    inline
+    int64_t
+    AtomicOperation::AtomicInc(volatile int64_t& mem)
+    {
+        return os::arch::AtomicOperation::AtomicInc(mem);
     }
 
     inline
     uint32_t
-    AtomicOperation::AtomicSub32(volatile uint32_t& mem, uint32_t subtrahend)
+    AtomicOperation::AtomicDec(volatile uint32_t& mem)
     {
-        return os::arch::AtomicOperation::AtomicSub32(mem, subtrahend);
+        return os::arch::AtomicOperation::AtomicDec(mem);
     }
 
     inline
-    uint32_t
-    AtomicOperation::AtomicInc32(volatile uint32_t& mem)
+    int32_t
+    AtomicOperation::AtomicDec(volatile int32_t& mem)
     {
-        return os::arch::AtomicOperation::AtomicInc32(mem);
+        return os::arch::AtomicOperation::AtomicDec(mem);
     }
 
     inline
-    uint32_t
-    AtomicOperation::AtomicDec32(volatile uint32_t& mem)
+    uint64_t
+    AtomicOperation::AtomicDec(volatile uint64_t& mem)
     {
-        return os::arch::AtomicOperation::AtomicDec32(mem);
+        return os::arch::AtomicOperation::AtomicDec(mem);
+    }
+
+    inline
+    int64_t
+    AtomicOperation::AtomicDec(volatile int64_t& mem)
+    {
+        return os::arch::AtomicOperation::AtomicDec(mem);
     }
 }
 

--- a/modules/capu/include/capu/os/MacOSX/AtomicOperation.h
+++ b/modules/capu/include/capu/os/MacOSX/AtomicOperation.h
@@ -1,0 +1,159 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef CAPU_MACOSX_ATOMICOPERATION_H
+#define CAPU_MACOSX_ATOMICOPERATION_H
+
+namespace capu
+{
+    namespace os
+    {
+        class AtomicOperation
+        {
+        public:
+            static uint32_t AtomicAdd(volatile uint32_t& mem, uint32_t summand);
+            static int32_t  AtomicAdd(volatile int32_t& mem, int32_t summand);
+            static uint64_t AtomicAdd(volatile uint64_t& mem, uint64_t summand);
+            static int64_t  AtomicAdd(volatile int64_t& mem, int64_t summand);
+
+            static uint32_t AtomicSub(volatile uint32_t& mem, uint32_t subtrahend);
+            static int32_t  AtomicSub(volatile int32_t& mem, int32_t subtrahend);
+            static uint64_t AtomicSub(volatile uint64_t& mem, uint64_t subtrahend);
+            static int64_t  AtomicSub(volatile int64_t& mem, int64_t subtrahend);
+
+            static uint32_t AtomicInc(volatile uint32_t& mem);
+            static int32_t  AtomicInc(volatile int32_t& mem);
+            static uint64_t AtomicInc(volatile uint64_t& mem);
+            static int64_t  AtomicInc(volatile int64_t& mem);
+
+            static uint32_t AtomicDec(volatile uint32_t& mem);
+            static int32_t  AtomicDec(volatile int32_t& mem);
+            static uint64_t AtomicDec(volatile uint64_t& mem);
+            static int64_t  AtomicDec(volatile int64_t& mem);
+        };
+
+        inline
+        uint32_t
+        AtomicOperation::AtomicAdd(volatile uint32_t& mem, uint32_t summand)
+        {
+            return __sync_fetch_and_add(&mem, summand);
+        }
+
+        inline
+        int32_t
+        AtomicOperation::AtomicAdd(volatile int32_t& mem, int32_t summand)
+        {
+            return __sync_fetch_and_add(&mem, summand);
+        }
+
+        inline
+        uint64_t
+        AtomicOperation::AtomicAdd(volatile uint64_t& mem, uint64_t summand)
+        {
+            return __sync_fetch_and_add(&mem, summand);
+        }
+
+        inline
+        int64_t
+        AtomicOperation::AtomicAdd(volatile int64_t& mem, int64_t summand)
+        {
+            return __sync_fetch_and_add(&mem, summand);
+        }
+
+        inline
+        uint32_t
+        AtomicOperation::AtomicSub(volatile uint32_t& mem, uint32_t subtrahend)
+        {
+            return __sync_fetch_and_sub(&mem, subtrahend);
+        }
+
+        inline
+        int32_t
+        AtomicOperation::AtomicSub(volatile int32_t& mem, int32_t subtrahend)
+        {
+            return __sync_fetch_and_sub(&mem, subtrahend);
+        }
+
+        inline
+        uint64_t
+        AtomicOperation::AtomicSub(volatile uint64_t& mem, uint64_t subtrahend)
+        {
+            return __sync_fetch_and_sub(&mem, subtrahend);
+        }
+
+        inline
+        int64_t
+        AtomicOperation::AtomicSub(volatile int64_t& mem, int64_t subtrahend)
+        {
+            return __sync_fetch_and_sub(&mem, subtrahend);
+        }
+
+        inline
+        uint32_t
+        AtomicOperation::AtomicInc(volatile uint32_t& mem)
+        {
+            return __sync_fetch_and_add(&mem, 1);
+        }
+
+        inline
+        int32_t
+        AtomicOperation::AtomicInc(volatile int32_t& mem)
+        {
+            return __sync_fetch_and_add(&mem, 1);
+        }
+
+        inline
+        uint64_t
+        AtomicOperation::AtomicInc(volatile uint64_t& mem)
+        {
+            return __sync_fetch_and_add(&mem, 1);
+        }
+
+        inline
+        int64_t
+        AtomicOperation::AtomicInc(volatile int64_t& mem)
+        {
+            return __sync_fetch_and_add(&mem, 1);
+        }
+
+        inline
+        uint32_t
+        AtomicOperation::AtomicDec(volatile uint32_t& mem)
+        {
+            return __sync_fetch_and_sub(&mem, 1);
+        }
+
+        inline
+        int32_t
+        AtomicOperation::AtomicDec(volatile int32_t& mem)
+        {
+            return __sync_fetch_and_sub(&mem, 1);
+        }
+
+        inline
+        uint64_t
+        AtomicOperation::AtomicDec(volatile uint64_t& mem)
+        {
+            return __sync_fetch_and_sub(&mem, 1);
+        }
+
+        inline
+        int64_t
+        AtomicOperation::AtomicDec(volatile int64_t& mem)
+        {
+            return __sync_fetch_and_sub(&mem, 1);
+        }
+    }
+}
+#endif

--- a/modules/capu/include/capu/os/MacOSX/X86_32/AtomicOperation.h
+++ b/modules/capu/include/capu/os/MacOSX/X86_32/AtomicOperation.h
@@ -17,6 +17,7 @@
 #ifndef CAPU_MACOSX_X86_32_ATOMICOPERATION_H
 #define CAPU_MACOSX_X86_32_ATOMICOPERATION_H
 
+#include <capu/os/MacOSX/AtomicOperation.h>
 
 namespace capu
 {
@@ -24,57 +25,16 @@ namespace capu
     {
         namespace arch
         {
-            class AtomicOperation
+            class AtomicOperation: private capu::os::AtomicOperation
             {
             public:
-                static uint32_t AtomicAdd32(volatile uint32_t& mem, uint32_t summand);
-                static uint32_t AtomicSub32(volatile uint32_t& mem, uint32_t subtrahend);
-                static uint32_t AtomicInc32(volatile uint32_t& mem);
-                static uint32_t AtomicDec32(volatile uint32_t& mem);
+                using capu::os::AtomicOperation::AtomicAdd;
+                using capu::os::AtomicOperation::AtomicSub;
+                using capu::os::AtomicOperation::AtomicInc;
+                using capu::os::AtomicOperation::AtomicDec;
             };
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicAdd32(volatile uint32_t& mem, uint32_t summand)
-            {
-                //This code comes from the Apache APR project (apache-apr/1.4.2/atomic/unix/ia32.c)
-                asm volatile("lock; xadd %0,%1"
-                             : "=r"(summand), "=m"(mem)
-                             : "0"(summand), "m"(mem)
-                             : "memory", "cc");
-
-                return summand;
-            }
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicSub32(volatile uint32_t& mem, uint32_t subtrahend)
-            {
-                //This code comes from the Apache APR project (apache-apr/1.4.2/atomic/unix/ia32.c)
-
-                int32_t summand = subtrahend * -1;
-                asm volatile("lock; xadd %0,%1"
-                             : "=r"(summand), "=m"(mem)
-                             : "0"(summand), "m"(mem)
-                             : "memory", "cc");
-
-                return summand;
-            }
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicInc32(volatile uint32_t& mem)
-            {
-                return AtomicAdd32(mem, 1);
-            }
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicDec32(volatile uint32_t& mem)
-            {
-                return AtomicSub32(mem, 1);
-            }
         }
     }
 }
+
 #endif

--- a/modules/capu/include/capu/os/MacOSX/X86_64/AtomicOperation.h
+++ b/modules/capu/include/capu/os/MacOSX/X86_64/AtomicOperation.h
@@ -17,6 +17,7 @@
 #ifndef CAPU_MACOSX_X86_64_ATOMICOPERATION_H
 #define CAPU_MACOSX_X86_64_ATOMICOPERATION_H
 
+#include <capu/os/MacOSX/AtomicOperation.h>
 
 namespace capu
 {
@@ -24,57 +25,16 @@ namespace capu
     {
         namespace arch
         {
-            class AtomicOperation
+            class AtomicOperation: private capu::os::AtomicOperation
             {
             public:
-                static uint32_t AtomicAdd32(volatile uint32_t& mem, uint32_t summand);
-                static uint32_t AtomicSub32(volatile uint32_t& mem, uint32_t subtrahend);
-                static uint32_t AtomicInc32(volatile uint32_t& mem);
-                static uint32_t AtomicDec32(volatile uint32_t& mem);
+                using capu::os::AtomicOperation::AtomicAdd;
+                using capu::os::AtomicOperation::AtomicSub;
+                using capu::os::AtomicOperation::AtomicInc;
+                using capu::os::AtomicOperation::AtomicDec;
             };
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicAdd32(volatile uint32_t& mem, uint32_t summand)
-            {
-                //This code comes from the Apache APR project (apache-apr/1.4.2/atomic/unix/ia32.c)
-                asm volatile("lock; xadd %0,%1"
-                             : "=r"(summand), "=m"(mem)
-                             : "0"(summand), "m"(mem)
-                             : "memory", "cc");
-
-                return summand;
-            }
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicSub32(volatile uint32_t& mem, uint32_t subtrahend)
-            {
-                //This code comes from the Apache APR project (apache-apr/1.4.2/atomic/unix/ia32.c)
-
-                int32_t summand = subtrahend * -1;
-                asm volatile("lock; xadd %0,%1"
-                             : "=r"(summand), "=m"(mem)
-                             : "0"(summand), "m"(mem)
-                             : "memory", "cc");
-
-                return summand;
-            }
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicInc32(volatile uint32_t& mem)
-            {
-                return AtomicAdd32(mem, 1);
-            }
-
-            inline
-            uint32_t
-            AtomicOperation::AtomicDec32(volatile uint32_t& mem)
-            {
-                return AtomicSub32(mem, 1);
-            }
         }
     }
 }
+
 #endif

--- a/modules/capu/include/capu/util/SmartPointer.h
+++ b/modules/capu/include/capu/util/SmartPointer.h
@@ -121,7 +121,7 @@ namespace capu
          * If the object does not exist, 0 ist returned
          * @return reference count
          */
-        capu::uint32_t getRefCount() const;
+        capu::uint_t getRefCount() const;
 
         /**
          * Cast a SmartPointer of type X to type T
@@ -132,7 +132,7 @@ namespace capu
 
     private:
         T* mData;
-        capu::uint32_t* mReferenceCount;
+        capu::uint_t* mReferenceCount;
 
         void incRefCount();
         void decRefCount();
@@ -157,7 +157,7 @@ namespace capu
         if (mData != ptr)
         {
             mData = ptr;
-            mReferenceCount = new capu::uint32_t(0);
+            mReferenceCount = new capu::uint_t(0);
             incRefCount();
         }
     }
@@ -214,7 +214,7 @@ namespace capu
             decRefCount();
 
             mData = ptr;
-            mReferenceCount = new capu::uint32_t(0);
+            mReferenceCount = new capu::uint_t(0);
 
             incRefCount();
         }
@@ -268,7 +268,7 @@ namespace capu
     {
         if (mReferenceCount)
         {
-            capu::AtomicOperation::AtomicInc32(*mReferenceCount);
+            capu::AtomicOperation::AtomicInc(*mReferenceCount);
         }
     }
 
@@ -278,7 +278,7 @@ namespace capu
     {
         if (mReferenceCount)
         {
-            uint32_t oldValue = capu::AtomicOperation::AtomicDec32(*mReferenceCount);
+            uint32_t oldValue = capu::AtomicOperation::AtomicDec(*mReferenceCount);
             if (--oldValue == 0)
             {
                 freeData();
@@ -312,7 +312,7 @@ namespace capu
 
     template<class T>
     inline
-    capu::uint32_t SmartPointer<T>::getRefCount() const
+    capu::uint_t SmartPointer<T>::getRefCount() const
     {
         if (mReferenceCount != 0)
         {

--- a/modules/capu/test/container/BlockingQueueTest.cpp
+++ b/modules/capu/test/container/BlockingQueueTest.cpp
@@ -45,7 +45,7 @@ public:
             mQueue.push(val);
             capu::uint32_t sleepTime = rand() % 100;
             capu::Thread::Sleep(sleepTime);
-            capu::AtomicOperation::AtomicAdd32(mSum, val);
+            capu::AtomicOperation::AtomicAdd(mSum, val);
         }
     }
 };
@@ -72,7 +72,7 @@ public:
         {
             capu::uint32_t tmp = 0;
             EXPECT_EQ(capu::CAPU_OK, mQueue.pop(&tmp));
-            capu::AtomicOperation::AtomicAdd32(mSum, tmp);
+            capu::AtomicOperation::AtomicAdd(mSum, tmp);
         }
     }
 };

--- a/modules/capu/test/os/AtomicOperationTest.cpp
+++ b/modules/capu/test/os/AtomicOperationTest.cpp
@@ -39,10 +39,10 @@ class AtomicOperationIncrementThread : public capu::Runnable
 public:
     void run()
     {
-        capu::uint32_t oldValue = 0;
-        for (capu::uint32_t i = 0; i < AtomicGlobals::n; i++)
+        capu::uint_t oldValue = 0;
+        for (capu::uint_t i = 0; i < AtomicGlobals::n; i++)
         {
-            oldValue += capu::AtomicOperation::AtomicInc32(AtomicGlobals::var);
+            oldValue += capu::AtomicOperation::AtomicInc(AtomicGlobals::var);
         }
 
         AtomicGlobals::mutex.lock();
@@ -56,10 +56,10 @@ class AtomicOperationDecrementThread : public capu::Runnable
 public:
     void run()
     {
-        capu::uint32_t oldValue = 0;
-        for (capu::uint32_t i = 0; i < AtomicGlobals::n; i++)
+        capu::uint_t oldValue = 0;
+        for (capu::uint_t i = 0; i < AtomicGlobals::n; i++)
         {
-            oldValue += capu::AtomicOperation::AtomicDec32(AtomicGlobals::var);
+            oldValue += capu::AtomicOperation::AtomicDec(AtomicGlobals::var);
         }
 
         AtomicGlobals::mutex.lock();
@@ -75,32 +75,32 @@ public:
 
 TEST(AtomicOperation, Add)
 {
-    capu::uint32_t val = 100;
-    capu::uint32_t ret = capu::AtomicOperation::AtomicAdd32(val, 3);
+    capu::uint_t val = 100;
+    capu::uint_t ret = capu::AtomicOperation::AtomicAdd(val, 3);
     EXPECT_EQ(103u, val);
     EXPECT_EQ(100u, ret);
 }
 
 TEST(AtomicOperation, Sub)
 {
-    capu::uint32_t val = 13;
-    capu::uint32_t ret = capu::AtomicOperation::AtomicSub32(val, 5);
+    capu::uint_t val = 13;
+    capu::uint_t ret = capu::AtomicOperation::AtomicSub(val, 5);
     EXPECT_EQ(8u, val);
     EXPECT_EQ(13u, ret);
 }
 
 TEST(AtomicOperation, Inc)
 {
-    capu::uint32_t val = 1;
-    capu::uint32_t ret = capu::AtomicOperation::AtomicInc32(val);
+    capu::uint_t val = 1;
+    capu::uint_t ret = capu::AtomicOperation::AtomicInc(val);
     EXPECT_EQ(2u, val);
     EXPECT_EQ(1u, ret);
 }
 
 TEST(AtomicOperation, Dec)
 {
-    capu::uint32_t val = 3;
-    capu::uint32_t ret = capu::AtomicOperation::AtomicDec32(val);
+    capu::uint_t val = 3;
+    capu::uint_t ret = capu::AtomicOperation::AtomicDec(val);
     EXPECT_EQ(2u, val);
     EXPECT_EQ(3u, ret);
 }

--- a/modules/capu/test/os/arch/X86_32/AtomicOperation.inc
+++ b/modules/capu/test/os/arch/X86_32/AtomicOperation.inc
@@ -19,7 +19,7 @@
 TEST(AtomicOperation, Add_Overflow_X86_32)
 {
     capu::uint32_t val = 4294967295u;
-    capu::uint32_t ret = capu::AtomicOperation::AtomicAdd32(val, 3);
+    capu::uint32_t ret = capu::AtomicOperation::AtomicAdd(val, 3);
     EXPECT_EQ(2u, val);
     EXPECT_EQ(4294967295u, ret);
 }
@@ -27,7 +27,7 @@ TEST(AtomicOperation, Add_Overflow_X86_32)
 TEST(AtomicOperation, Sub_Overflow_X86_32)
 {
     capu::uint32_t val = 0;
-    capu::uint32_t ret = capu::AtomicOperation::AtomicSub32(val, 5);
+    capu::uint32_t ret = capu::AtomicOperation::AtomicSub(val, 5);
     EXPECT_EQ(4294967291u, val);
     EXPECT_EQ(0u, ret);
 }

--- a/modules/capu/test/os/arch/X86_64/AtomicOperation.inc
+++ b/modules/capu/test/os/arch/X86_64/AtomicOperation.inc
@@ -17,21 +17,20 @@
 TEST(AtomicOperation, Add_NoOverflow_X86_64)
 {
     capu::uint32_t val = 4294967295u;
-    capu::uint32_t ret = capu::AtomicOperation::AtomicAdd32(val, 3);
+    capu::uint32_t ret = capu::AtomicOperation::AtomicAdd(val, 3);
     EXPECT_EQ((capu::uint32_t) 4294967298u, val);
     EXPECT_EQ(ret, 4294967295u);
 }
 
-//disabled until *64 methods are implemented
-/*TEST(AtomicOperation,Add64_Overflow_X86_64) {
+TEST(AtomicOperation,Add64_Overflow_X86_64) {
   capu::uint64_t val = 18446744073709551615u;
-  capu::AtomicOperation::AtomicAdd64(val, 3);
+  capu::AtomicOperation::AtomicAdd(val, 3);
   EXPECT_EQ((capu::uint32_t) 2,val);
 }
 
 TEST(AtomicOperation,Sub64_Overflow_X86_64) {
   capu::uint64_t val = 0;
-  capu::AtomicOperation::AtomicSub64(val, 5);
-  EXPECT_EQ((capu::uint32_t) 18446744073709551610u,val);
+  capu::AtomicOperation::AtomicSub(val, 5);
+  EXPECT_EQ(18446744073709551611u,val);
 }
-*/
+

--- a/modules/capu/test/util/ThreadPoolTest.cpp
+++ b/modules/capu/test/util/ThreadPoolTest.cpp
@@ -37,7 +37,7 @@ public:
 
     void run()
     {
-        capu::AtomicOperation::AtomicAdd32(Globals::var, 5);
+        capu::AtomicOperation::AtomicAdd(Globals::var, 5);
         capu::Thread::Sleep(10);
     }
 };
@@ -54,7 +54,7 @@ public:
 
     void run()
     {
-        capu::AtomicOperation::AtomicAdd32(Globals::var, 5);
+        capu::AtomicOperation::AtomicAdd(Globals::var, 5);
         m_semaphore.release();
         while (!isCancelRequested())
         {


### PR DESCRIPTION
I changed the interface of the AtomicOperations to a generic interface.

So it is possible to use a 64-Bit and a 32-Bit SmartPointer, which was needed to Support Arm64.

Before adding this patch, the Windows and Linux implementations need to be updated.

Best Regards, Aaron
