### PR TITLE
MacOSX 64-Bit Tests won't build

### DIFF
--- a/modules/capu/test/util/StringOutputStreamTest.cpp
+++ b/modules/capu/test/util/StringOutputStreamTest.cpp
@@ -68,7 +68,7 @@ namespace capu
 
     TEST_F(StringOutputStreamTest, WriteInt64)
     {
-        outputStream << 0x6464646432323232;
+        outputStream << 0x6464646432323232LL;
         outputStream.flush();
         EXPECT_STREQ("7234017282965516850", outputStream.c_str());
         EXPECT_EQ(19U, outputStream.length());
@@ -76,7 +76,7 @@ namespace capu
 
     TEST_F(StringOutputStreamTest, WriteUInt64)
     {
-        outputStream << 0x6464646432323232u;
+        outputStream << 0x6464646432323232uLL;
         outputStream.flush();
         EXPECT_STREQ("7234017282965516850", outputStream.c_str());
         EXPECT_EQ(19U, outputStream.length());


### PR DESCRIPTION
In MacOSX 64-Bit there is a differentiation between ::int64_t (which is long long) and a "long"-value, even though they have the same width.

If you pass a big value it is interpreted as "long"-value and not as a "long long"-value. Therefore the functions operator<<(int64_t) and operator<<(uint64_t) are ambiguous.

We may want to check if a similar issue exists on other operating systems.

---

StringOutputStreamTest.cpp:71:22: 
error: use of overloaded operator '<<' is ambiguous (with operand types 'capu::StringOutputStream' and 'long') outputStream << 0x6464646432323232;
